### PR TITLE
Add price display and discount popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # mico
+
+Demo brochure site showcasing product listings. Product cards now display
+example prices and discounts. A promotional popup appears after 20 seconds of
+inactivity prompting visitors to enter their name and phone number to claim a
+20% discount.

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -14,5 +14,41 @@
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800 antialiased">
   {% block content %}{% endblock %}
+  <div id="discount-popup" class="fixed inset-0 z-50 hidden flex items-center justify-center bg-black/50">
+    <div class="bg-white p-6 rounded-xl w-80">
+      <h2 class="text-lg font-semibold mb-2">Get 20% off</h2>
+      <p class="text-sm mb-4">Enter your name and phone number to receive a 20% discount.</p>
+      <form class="space-y-2">
+        <input type="text" placeholder="Name" class="w-full border rounded p-2" />
+        <input type="tel" placeholder="Phone number" class="w-full border rounded p-2" />
+        <div class="flex justify-end gap-2">
+          <button type="button" id="discount-close" class="px-3 py-1 border rounded">Close</button>
+          <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">Submit</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <script>
+    (function() {
+      let timer;
+      const popup = document.getElementById('discount-popup');
+      const closeBtn = document.getElementById('discount-close');
+      function showPopup() {
+        popup.classList.remove('hidden');
+      }
+      function resetTimer() {
+        popup.classList.add('hidden');
+        clearTimeout(timer);
+        timer = setTimeout(showPopup, 20000);
+      }
+      ['mousemove', 'keydown', 'click', 'touchstart'].forEach(evt => {
+        document.addEventListener(evt, resetTimer);
+      });
+      if (closeBtn) {
+        closeBtn.addEventListener('click', resetTimer);
+      }
+      resetTimer();
+    })();
+  </script>
 </body>
 </html>

--- a/core/templates/components/product_card.html
+++ b/core/templates/components/product_card.html
@@ -9,6 +9,12 @@
   <div class="p-4">
     <h3 class="text-base font-semibold line-clamp-2">{{ label|default:default_label }}</h3>
     <p class="mt-1 text-sm text-gray-500">{{ desc|default:default_desc }}</p>
+    {% with default_price="9.99" default_discount="20" %}
+    <div class="mt-2">
+      <span class="text-lg font-bold">${{ price|default:default_price }}</span>
+      <span class="ml-2 text-sm text-green-600">{{ discount|default:default_discount }}% off</span>
+    </div>
+    {% endwith %}
     <div class="mt-4 flex gap-2">
       <a href="#order" class="inline-flex items-center rounded-xl bg-blue-600 text-white px-4 py-2 text-sm font-semibold hover:bg-blue-700">{% trans '{{Order}}' %}</a>
       <a href="#products" class="inline-flex items-center rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm font-semibold hover:bg-gray-50">{% trans '{{More Info}}' %}</a>


### PR DESCRIPTION
## Summary
- show example price and discount on product cards
- add inactivity popup offering 20% off after 20 seconds
- document new pricing and popup features in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b375e4e08330acb238ed18250411