### PR TITLE
Add dynamic product listing with order modal and search

### DIFF
--- a/core/templates/all_products.html
+++ b/core/templates/all_products.html
@@ -1,0 +1,90 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+  <!-- NAVBAR -->
+  <nav data-site-nav class="sticky top-0 z-40 border-b border-gray-200 transition">
+    <div class="container mx-auto px-4 h-14 flex items-center justify-between">
+      <ul class="hidden md:flex items-center gap-6 text-sm font-medium text-gray-700">
+        <li><a href="/" class="hover:text-brand-600">{% trans 'Home' %}</a></li>
+        <li><a href="/products/" class="hover:text-brand-600">{% trans 'Products' %}</a></li>
+      </ul>
+
+      <a href="/" class="md:absolute left-1/2 -translate-x-1/2 text-base font-extrabold text-brand-700">
+        {% trans '{{BrandName}}' %}
+      </a>
+
+      <div class="flex items-center gap-3 ml-auto">
+        <button id="menuToggle" class="md:hidden inline-flex items-center justify-center rounded-xl p-2 bg-white/40 backdrop-blur-sm ring-1 ring-inset ring-gray-200 hover:bg-white/70 transition">
+          <span class="sr-only">Menu</span>
+          <div id="menuIcon" class="w-6 h-4 relative">
+            <span class="line line-1 absolute inset-x-0 top-0 h-0.5 bg-gray-800 rounded"></span>
+            <span class="line line-2 absolute inset-x-0 top-1/2 -translate-y-1/2 h-0.5 bg-gray-800 rounded"></span>
+            <span class="line line-3 absolute inset-x-0 bottom-0 h-0.5 bg-gray-800 rounded"></span>
+          </div>
+        </button>
+      </div>
+    </div>
+
+    <div class="md:hidden hidden border-t border-gray-200 bg-white/95 backdrop-blur" id="mobileMenu">
+      <div class="container mx-auto px-4 py-3 flex flex-col gap-1 text-sm">
+        <a class="py-2 hover:text-brand-600" href="/">{% trans 'Home' %}</a>
+        <a class="py-2 hover:text-brand-600" href="/products/">{% trans 'Products' %}</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container mx-auto px-4 py-12">
+    <h1 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900 mb-4">{% trans 'All Products' %}</h1>
+    <input id="product-search" type="text" placeholder="{% trans 'Search products' %}" class="mb-6 w-full p-3 rounded-xl border-gray-300" />
+    <div id="all-products" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6"></div>
+  </main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (async function() {
+    const API_BASE = window.APP_CONFIG.API_BASE;
+    let products = [];
+    try {
+      const res = await fetch(`${API_BASE}/products/`);
+      if (!res.ok) throw new Error('Network');
+      products = await res.json();
+    } catch (err) {
+      products = [{ id: 1, name: 'Sample Product', image_url: '' }];
+    }
+
+    function card(p) {
+      return `
+        <div class="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden flex flex-col">
+          <div class="aspect-square overflow-hidden bg-gray-100">
+            <img src="${p.image_url || 'https://img.freepik.com/free-vector/illustration-gallery-icon_53876-27002.jpg'}" alt="${p.name}" class="h-full w-full object-cover">
+          </div>
+          <div class="p-4 flex flex-col flex-1">
+            <h3 class="text-base font-semibold text-gray-900 line-clamp-2">${p.name}</h3>
+            <div class="mt-auto">
+              <button data-product-id="${p.id}" class="buy-btn mt-4 inline-flex items-center rounded-xl bg-blue-600 text-white px-4 py-2 text-sm font-semibold hover:bg-blue-700">{% trans 'Buy' %}</button>
+            </div>
+          </div>
+        </div>`;
+    }
+
+    const container = document.getElementById('all-products');
+    function render(list) {
+      container.innerHTML = list.map(card).join('');
+    }
+    render(products);
+
+    container.addEventListener('click', function(e) {
+      const btn = e.target.closest('.buy-btn');
+      if (btn) openOrderModal(btn.dataset.productId);
+    });
+
+    document.getElementById('product-search').addEventListener('input', function(e) {
+      const q = e.target.value.toLowerCase();
+      const filtered = products.filter(p => p.name.toLowerCase().includes(q));
+      render(filtered);
+    });
+  })();
+</script>
+{% endblock %}

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -13,8 +13,47 @@
   <title>{% block title %}{% trans 'BrandName' %}{% endblock %}</title>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800 antialiased">
+  <div class="flex justify-end gap-2 p-2 text-xl">
+    <a href="/mk/" aria-label="Macedonian">🇲🇰</a>
+    <a href="/en/" aria-label="English">🇬🇧</a>
+    <a href="/al/" aria-label="Albanian">🇦🇱</a>
+  </div>
   {% block content %}{% endblock %}
-  
+
+  <!-- Order Modal -->
+  <div id="order-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50">
+    <div class="bg-white p-6 rounded-xl w-full max-w-md">
+      <form id="order-form" class="space-y-4">
+        <input type="hidden" id="order-product-id" name="product_id">
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Name</label>
+          <input type="text" name="name" class="mt-1 w-full rounded-xl border-gray-300 p-3" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Phone</label>
+          <input type="tel" name="phone" class="mt-1 w-full rounded-xl border-gray-300 p-3" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Address</label>
+          <input type="text" name="address" class="mt-1 w-full rounded-xl border-gray-300 p-3" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">City</label>
+          <input type="text" name="city" class="mt-1 w-full rounded-xl border-gray-300 p-3" required>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Quantity</label>
+          <input type="number" name="quantity" min="1" value="1" class="mt-1 w-full rounded-xl border-gray-300 p-3" required>
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" id="order-cancel" class="px-4 py-2 rounded-xl border">Cancel</button>
+          <button type="submit" class="px-4 py-2 rounded-xl bg-blue-600 text-white">Submit</button>
+        </div>
+        <p id="order-message" class="text-sm"></p>
+      </form>
+    </div>
+  </div>
+
   <div id="discount-popup" class="fixed inset-0 z-50 hidden flex items-center justify-center bg-black/50">
     <div class="bg-white p-6 rounded-xl w-80">
       <h2 class="text-lg font-semibold mb-2">Get 20% off</h2>
@@ -29,6 +68,62 @@
       </form>
     </div>
   </div>
+
+  <script>
+    window.APP_CONFIG = Object.assign({API_BASE: '', USE_MOCK_ORDER: true}, window.APP_CONFIG || {});
+
+    function submitOrder(data) {
+      if (window.APP_CONFIG.USE_MOCK_ORDER) {
+        return new Promise((resolve) => setTimeout(() => resolve({ id: 123 }), 1000));
+      }
+      return fetch(`${window.APP_CONFIG.API_BASE}/public/orders/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      }).then((res) => {
+        if (!res.ok) throw new Error('Network');
+        return res.json();
+      });
+    }
+
+    function closeOrderModal() {
+      document.getElementById('order-modal').classList.add('hidden');
+    }
+
+    window.openOrderModal = function (productId) {
+      document.getElementById('order-product-id').value = productId;
+      document.getElementById('order-message').textContent = '';
+      document.getElementById('order-modal').classList.remove('hidden');
+    };
+
+    document.getElementById('order-cancel').addEventListener('click', closeOrderModal);
+    document.getElementById('order-modal').addEventListener('click', function (e) {
+      if (e.target === e.currentTarget) closeOrderModal();
+    });
+
+    document.getElementById('order-form').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const form = e.target;
+      const data = {
+        name: form.name.value,
+        phone: form.phone.value,
+        address: form.address.value,
+        city: form.city.value,
+        product_id: form.product_id.value,
+        quantity: form.quantity.value
+      };
+      const msg = document.getElementById('order-message');
+      msg.textContent = 'Submitting...';
+      try {
+        await submitOrder(data);
+        msg.textContent = 'Order placed successfully!';
+        form.reset();
+        setTimeout(closeOrderModal, 1500);
+      } catch (err) {
+        msg.textContent = 'Error placing order.';
+      }
+    });
+  </script>
 
   <script>
     (function() {
@@ -53,5 +148,7 @@
       setTimeout(showPopup, 30000); // Show after 30s
     })();
   </script>
+
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -17,15 +17,6 @@
       </a>
 
       <div class="flex items-center gap-3 ml-auto">
-        <!-- Language switcher (replace with set_language form if you use it) -->
-        <div class="hidden sm:flex items-center gap-1 rounded-xl border border-gray-200 bg-white/70 backdrop-blur px-2 py-1">
-          <a href="/mk/" class="px-2 py-1 text-xs hover:text-brand-600">MK</a>
-          <span class="text-gray-300">|</span>
-          <a href="/en/" class="px-2 py-1 text-xs hover:text-brand-600">EN</a>
-          <span class="text-gray-300">|</span>
-          <a href="/al/" class="px-2 py-1 text-xs hover:text-brand-600">AL</a>
-        </div>
-
         <!-- hamburger -->
         <button id="menuToggle" class="md:hidden inline-flex items-center justify-center rounded-xl p-2 bg-white/40 backdrop-blur-sm ring-1 ring-inset ring-gray-200 hover:bg-white/70 transition">
           <span class="sr-only">Menu</span>
@@ -212,25 +203,16 @@
       </div>
     </section>
 
-    <!-- PRODUCTS: WORKING CAROUSEL (uses your product_card partial) -->
+    <!-- PRODUCTS: dynamic featured -->
     <section id="products" class="py-12">
       <div class="mb-6 flex items-end justify-between">
-        <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'All Products' %}</h2>
-        <div class="flex items-center gap-2">
-          <div class="swiper-button-prev prods-prev"></div>
-          <div class="swiper-button-next prods-next"></div>
-        </div>
+        <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'Featured Products' %}</h2>
+        <a href="/products/" class="text-sm text-brand-600 hover:underline">{% trans 'View all' %}</a>
       </div>
 
-      <div class="swiper" id="products-swiper">
-        <div class="swiper-wrapper">
-          {% for p in products %}
-            <div class="swiper-slide">
-              {% include "components/product_card.html" with label=p.label desc=p.desc img=p.img %}
-            </div>
-          {% endfor %}
-        </div>
-        <div class="swiper-pagination prods-dots mt-6"></div>
+      <div class="swiper" id="featured-swiper">
+        <div class="swiper-wrapper" id="featured-products"></div>
+        <div class="swiper-pagination featured-dots mt-6"></div>
       </div>
     </section>
 
@@ -301,7 +283,7 @@
 {% endblock %}
 
 {% block scripts %}
-<!-- INIT: Certificates & Products Swipers (WORKING) -->
+<!-- INIT: Certificates & Featured Products -->
 <script>
   new Swiper('#certs-swiper', {
     slidesPerView: 1.2,
@@ -325,27 +307,57 @@
     mousewheel: { forceToAxis: true },
   });
 
-  new Swiper('#products-swiper', {
-    slidesPerView: 1.1,
-    spaceBetween: 16,
-    loop: true,
-    grabCursor: true,
-    breakpoints: {
-      640:  { slidesPerView: 2.1, spaceBetween: 20 },
-      768:  { slidesPerView: 3,   spaceBetween: 24 },
-      1024: { slidesPerView: 4,   spaceBetween: 24 },
-      1280: { slidesPerView: 5,   spaceBetween: 28 },
-    },
-    navigation: {
-      nextEl: '.prods-next',
-      prevEl: '.prods-prev',
-    },
-    pagination: {
-      el: '.prods-dots',
-      clickable: true,
-    },
-    keyboard: { enabled: true },
-    mousewheel: { forceToAxis: true },
-  });
+  async function loadFeatured() {
+    const API_BASE = window.APP_CONFIG.API_BASE;
+    let products = [];
+    try {
+      const res = await fetch(`${API_BASE}/products/`);
+      if (!res.ok) throw new Error('Network');
+      products = await res.json();
+    } catch (err) {
+      products = [{ id: 1, name: 'Sample Product', image_url: '' }];
+    }
+    const featured = products.slice(0, 3);
+    const wrapper = document.getElementById('featured-products');
+    wrapper.innerHTML = featured.map(p => `
+      <div class="swiper-slide">
+        <div class="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden flex flex-col">
+          <div class="aspect-square overflow-hidden bg-gray-100">
+            <img src="${p.image_url || 'https://img.freepik.com/free-vector/illustration-gallery-icon_53876-27002.jpg'}" alt="${p.name}" class="h-full w-full object-cover">
+          </div>
+          <div class="p-4 flex flex-col flex-1">
+            <h3 class="text-base font-semibold text-gray-900 line-clamp-2">${p.name}</h3>
+            <div class="mt-auto">
+              <button data-product-id="${p.id}" class="buy-btn mt-4 inline-flex items-center rounded-xl bg-blue-600 text-white px-4 py-2 text-sm font-semibold hover:bg-blue-700">{% trans 'Buy' %}</button>
+            </div>
+          </div>
+        </div>
+      </div>`).join('');
+
+    new Swiper('#featured-swiper', {
+      slidesPerView: 1.1,
+      spaceBetween: 16,
+      loop: true,
+      grabCursor: true,
+      breakpoints: {
+        640:  { slidesPerView: 2.1, spaceBetween: 20 },
+        768:  { slidesPerView: 3,   spaceBetween: 24 },
+        1024: { slidesPerView: 4,   spaceBetween: 24 },
+      },
+      pagination: {
+        el: '.featured-dots',
+        clickable: true,
+      },
+      keyboard: { enabled: true },
+      mousewheel: { forceToAxis: true },
+    });
+
+    wrapper.addEventListener('click', function (e) {
+      const btn = e.target.closest('.buy-btn');
+      if (btn) openOrderModal(btn.dataset.productId);
+    });
+  }
+
+  loadFeatured();
 </script>
 {% endblock %}

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -8,3 +8,8 @@ class IndexViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "index.html")
 
+    def test_products_page_returns_success(self):
+        response = self.client.get(reverse("products"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "all_products.html")
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('products/', views.products_page, name='products'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -3,3 +3,7 @@ from django.shortcuts import render
 
 def index(request):
     return render(request, 'index.html')
+
+
+def products_page(request):
+    return render(request, 'all_products.html')


### PR DESCRIPTION
## Summary
- Fetch products from API and show featured carousel with "Buy" modal
- Add full product listing page with search and mock COD order support
- Move language selector to flag bar and wire up order submission feature flag

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a2dedbd95c8330ad6b6a71ea629f83