### PR TITLE
Refactor navigation and add standalone pages

### DIFF
--- a/core/templates/about.html
+++ b/core/templates/about.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+{% load i18n static %}
+
+{% block content %}
+<main class="container mx-auto px-4">
+  <section class="py-12">
+    <h1 class="text-2xl font-bold mb-4">{% trans 'About Us' %}</h1>
+    <p class="text-gray-700">{% trans 'Our company delivers certified health products with transparent service and long-term partnerships.' %}</p>
+  </section>
+
+  <section id="certs" class="py-12">
+    <div class="mb-6 flex items-end justify-between">
+      <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'Certificates & Compliance' %}</h2>
+      <div class="flex items-center gap-2">
+        <div class="swiper-button-prev certs-prev"></div>
+        <div class="swiper-button-next certs-next"></div>
+      </div>
+    </div>
+    <div class="swiper" id="certs-swiper">
+      <div class="swiper-wrapper" id="certs-wrapper"></div>
+      <div class="swiper-pagination certs-dots mt-6"></div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  async function loadCerts() {
+    const lang = document.documentElement.lang || 'en';
+    try {
+      const res = await fetch("{% static 'mock/certificates.json' %}");
+      const certs = await res.json();
+      const wrapper = document.getElementById('certs-wrapper');
+      wrapper.innerHTML = certs.map(c => `
+        <div class=\"swiper-slide\">
+          <div class=\"rounded-2xl border border-gray-200 bg-white p-4 h-full card-hover\">
+            <img src=\"${c.image_url}\" class=\"w-full h-48 object-cover rounded-lg\" alt=\"${c.name[lang] || c.name.en}\">
+            <div class=\"mt-3\">
+              <div class=\"text-sm font-semibold\">${c.name[lang] || c.name.en}</div>
+              <p class=\"text-xs text-gray-600\">${c.description[lang] || c.description.en}</p>
+            </div>
+          </div>
+        </div>
+      `).join('');
+      new Swiper('#certs-swiper', {
+        slidesPerView: 1.2,
+        spaceBetween: 16,
+        loop: true,
+        grabCursor: true,
+        breakpoints: {
+          640:  { slidesPerView: 2.2, spaceBetween: 20 },
+          768:  { slidesPerView: 3,   spaceBetween: 24 },
+          1024: { slidesPerView: 4,   spaceBetween: 24 },
+        },
+        navigation: { nextEl: '.certs-next', prevEl: '.certs-prev' },
+        pagination: { el: '.certs-dots', clickable: true },
+        keyboard: { enabled: true },
+        mousewheel: { forceToAxis: true },
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  loadCerts();
+</script>
+{% endblock %}

--- a/core/templates/contact.html
+++ b/core/templates/contact.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8 max-w-lg">
+  <h1 class="text-2xl font-bold mb-4">{% trans 'Contact Us' %}</h1>
+  <form class="space-y-4" method="post">
+    {% csrf_token %}
+    <div>
+      <label class="block text-sm font-medium text-gray-700">{% trans 'Name' %}</label>
+      <input class="mt-1 block w-full rounded-xl border-gray-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-500 p-3" type="text" name="name" placeholder="{% trans 'Name' %}">
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-gray-700">{% trans 'Email' %}</label>
+      <input class="mt-1 block w-full rounded-xl border-gray-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-500 p-3" type="email" name="email" placeholder="{% trans 'Email' %}">
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-gray-700">{% trans 'Message' %}</label>
+      <textarea class="mt-1 block w-full rounded-xl border-gray-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-500 p-3" name="message" rows="4" placeholder="{% trans 'Message' %}"></textarea>
+    </div>
+    <button class="inline-flex items-center rounded-xl bg-brand-600 text-white px-5 py-3 text-sm font-semibold hover:bg-brand-700 shadow-sm" type="submit">
+      {% trans 'Send' %}
+    </button>
+  </form>
+</div>
+{% endblock %}

--- a/core/templates/faq.html
+++ b/core/templates/faq.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-4">{% trans 'FAQ' %}</h1>
+  <dl class="space-y-4">
+    <div>
+      <dt class="font-semibold">{% trans 'How do I place an order?' %}</dt>
+      <dd class="text-gray-700">{% trans 'Select a product and follow the checkout instructions.' %}</dd>
+    </div>
+    <div>
+      <dt class="font-semibold">{% trans 'What payment methods are available?' %}</dt>
+      <dd class="text-gray-700">{% trans 'We currently offer cash on delivery.' %}</dd>
+    </div>
+  </dl>
+</div>
+{% endblock %}

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -35,8 +35,8 @@
             {% trans 'Order online and pay in person. We provide an invoice and follow up if needed.' %}
           </p>
           <div class="mt-8 flex flex-wrap gap-3">
-            <a href="#products" class="inline-flex items-center rounded-xl bg-white text-brand-800 px-6 py-3 text-sm font-semibold shadow-md hover:bg-gray-100">
-              {% trans 'Browse Products' %}
+            <a href="/products/" class="inline-flex items-center rounded-xl bg-white text-brand-800 px-6 py-3 text-sm font-semibold shadow-md hover:bg-gray-100">
+              {% trans 'Our Products' %}
             </a>
             <a href="#certs" class="inline-flex items-center rounded-xl border border-white/40 px-6 py-3 text-sm font-semibold hover:bg-white/10">
               {% trans 'View Certificates' %}
@@ -120,40 +120,22 @@
     <!-- PRODUCTS: dynamic featured -->
     <section id="products" class="py-12">
       <div class="mb-6 flex items-end justify-between">
-        <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'Featured Products' %}</h2>
+        <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'Products' %}</h2>
         <a href="/products/" class="text-sm text-brand-600 hover:underline">{% trans 'View all' %}</a>
       </div>
 
       <div class="swiper" id="featured-swiper">
         <div class="swiper-wrapper" id="featured-products"></div>
-        <div class="swiper-pagination featured-dots mt-6"></div>
+      <div class="swiper-pagination featured-dots mt-6"></div>
       </div>
     </section>
 
-    <!-- CONTACT -->
-    <section id="contact" class="py-12">
-      <div class="max-w-lg">
-        <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'Contact Us' %}</h2>
-        <form class="mt-6 space-y-4" method="post">
-          {% csrf_token %}
-          <div>
-            <label class="block text-sm font-medium text-gray-700">{% trans 'Name' %}</label>
-            <input class="mt-1 block w-full rounded-xl border-gray-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-500 p-3" type="text" name="name" placeholder="{% trans 'Name' %}">
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">{% trans 'Email' %}</label>
-            <input class="mt-1 block w-full rounded-xl border-gray-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-500 p-3" type="email" name="email" placeholder="{% trans 'Email' %}">
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">{% trans 'Message' %}</label>
-            <textarea class="mt-1 block w-full rounded-xl border-gray-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-500 p-3" name="message" rows="4" placeholder="{% trans 'Message' %}"></textarea>
-          </div>
-          <button class="inline-flex items-center rounded-xl bg-brand-600 text-white px-5 py-3 text-sm font-semibold hover:bg-brand-700 shadow-sm" type="submit">
-            {% trans 'Send' %}
-          </button>
-        </form>
-      </div>
+    <!-- DEVELOPMENT -->
+    <section id="development" class="py-12">
+      <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900">{% trans 'Development' %}</h2>
+      <p class="mt-2 text-gray-600">{% trans 'Our experience with orders and clients grows every day.' %}</p>
     </section>
+
   </main>
 
   <!-- FOOTER -->
@@ -175,9 +157,9 @@
         <div>
           <div class="font-semibold">{% trans 'Useful Links' %}</div>
           <ul class="mt-2 space-y-1 text-brand-100">
-            <li><a href="#about" class="hover:text-white">{% trans 'About Us' %}</a></li>
-            <li><a href="#certs" class="hover:text-white">{% trans 'Certificates' %}</a></li>
-            <li><a href="#contact" class="hover:text-white">{% trans 'Contact' %}</a></li>
+            <li><a href="/about/" class="hover:text-white">{% trans 'About Us' %}</a></li>
+            <li><a href="/faq/" class="hover:text-white">{% trans 'FAQ' %}</a></li>
+            <li><a href="/contact/" class="hover:text-white">{% trans 'Contact' %}</a></li>
           </ul>
         </div>
         <div>
@@ -269,14 +251,12 @@
       </div>`).join('');
 
     new Swiper('#featured-swiper', {
-      slidesPerView: 1.1,
+      slidesPerView: 1,
       spaceBetween: 16,
       loop: true,
       grabCursor: true,
       breakpoints: {
-        640:  { slidesPerView: 2.1, spaceBetween: 20 },
-        768:  { slidesPerView: 3,   spaceBetween: 24 },
-        1024: { slidesPerView: 4,   spaceBetween: 24 },
+        768:  { slidesPerView: 2, spaceBetween: 24 },
       },
       pagination: {
         el: '.featured-dots',

--- a/core/templates/partials/_navbar.html
+++ b/core/templates/partials/_navbar.html
@@ -1,36 +1,39 @@
 {% load i18n static %}
 <nav class="bg-white border-b" data-site-nav>
-  <div class="container mx-auto flex items-center justify-between h-12 px-4">
-    <a href="/" class="font-bold">{% trans 'Home' %}</a>
-    <div class="hidden md:flex space-x-4">
+  <div class="container mx-auto h-12 px-4 flex items-center justify-between">
+    <button id="menuToggle" class="md:hidden">☰</button>
+
+    <a href="/" class="mx-auto md:mx-0 flex items-center">
+      <img src="https://dummyimage.com/80x40/ffffff/000000.png&text=Logo" alt="Logo" class="h-8" />
+    </a>
+
+    <div class="hidden md:flex md:space-x-4 md:ml-6">
+      <a href="/" class="hover:text-brand-600">{% trans 'Home' %}</a>
       <a href="/products/" class="hover:text-brand-600">{% trans 'Products' %}</a>
-      <a href="#about" class="hover:text-brand-600">{% trans 'About Us' %}</a>
-      <a href="#certs" class="hover:text-brand-600">{% trans 'Certificates' %}</a>
-      <a href="#contact" class="hover:text-brand-600">{% trans 'Contact' %}</a>
+      <a href="/about/" class="hover:text-brand-600">{% trans 'About Us' %}</a>
+      <a href="/faq/" class="hover:text-brand-600">{% trans 'FAQ' %}</a>
+      <a href="/contact/" class="hover:text-brand-600">{% trans 'Contact' %}</a>
     </div>
+
     <div class="flex items-center space-x-3 ml-auto">
       <div class="relative">
         <input id="nav-search" type="search" placeholder="{% trans 'Search' %}" class="border rounded px-2 py-1" />
         <ul id="nav-search-results" class="hidden absolute bg-white border mt-1 w-full"></ul>
       </div>
-      <form action="{% url 'set_language' %}" method="post">
+      <form action="{% url 'set_language' %}" method="post" class="flex items-center space-x-1">
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ request.path }}" />
-        <select name="language" onchange="this.form.submit()" class="border rounded px-2 py-1">
-          {% get_current_language as LANGUAGE_CODE %}
-          {% get_available_languages as LANGUAGES %}
-          {% for lang in LANGUAGES %}
-            <option value="{{ lang.0 }}" {% if lang.0 == LANGUAGE_CODE %}selected{% endif %}>{{ lang.1 }}</option>
-          {% endfor %}
-        </select>
+        <button type="submit" name="language" value="mk">🇲🇰</button>
+        <button type="submit" name="language" value="en">🇬🇧</button>
+        <button type="submit" name="language" value="sq">🇦🇱</button>
       </form>
-      <button id="menuToggle" class="md:hidden">☰</button>
     </div>
   </div>
   <div id="mobileMenu" class="md:hidden hidden px-4 pb-2 space-y-1">
+    <a href="/" class="block py-1">{% trans 'Home' %}</a>
     <a href="/products/" class="block py-1">{% trans 'Products' %}</a>
-    <a href="#about" class="block py-1">{% trans 'About Us' %}</a>
-    <a href="#certs" class="block py-1">{% trans 'Certificates' %}</a>
-    <a href="#contact" class="block py-1">{% trans 'Contact' %}</a>
+    <a href="/about/" class="block py-1">{% trans 'About Us' %}</a>
+    <a href="/faq/" class="block py-1">{% trans 'FAQ' %}</a>
+    <a href="/contact/" class="block py-1">{% trans 'Contact' %}</a>
   </div>
 </nav>

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,13 @@
 from django.urls import path
 from . import views
-from core.views import ProductPageFormView, ThankYouView, TestView
+from core.views import (
+    ProductPageFormView,
+    ThankYouView,
+    TestView,
+    AboutView,
+    FAQView,
+    ContactView,
+)
 
 app_name = "core"
 urlpatterns = [
@@ -12,4 +19,7 @@ urlpatterns = [
     ),
     path("thank-you/", ThankYouView.as_view(), name="thank-you"),
     path("test/", TestView.as_view(), name="test"),
+    path("about/", AboutView.as_view(), name="about"),
+    path("faq/", FAQView.as_view(), name="faq"),
+    path("contact/", ContactView.as_view(), name="contact"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -48,3 +48,15 @@ class TestView(TemplateView):
 
 class ThankYouView(TemplateView):
     template_name = "thank_you.html"
+
+
+class AboutView(TemplateView):
+    template_name = "about.html"
+
+
+class FAQView(TemplateView):
+    template_name = "faq.html"
+
+
+class ContactView(TemplateView):
+    template_name = "contact.html"

--- a/locale/mk/LC_MESSAGES/django.po
+++ b/locale/mk/LC_MESSAGES/django.po
@@ -89,3 +89,42 @@ msgstr "Нема залиха"
 
 msgid "View details"
 msgstr "Детали"
+
+msgid "Home"
+msgstr "Почетна"
+
+msgid "FAQ"
+msgstr "Прашања и одговори"
+
+msgid "Search"
+msgstr "Пребарај"
+
+msgid "Our Products"
+msgstr "Наши производи"
+
+msgid "About Us"
+msgstr "За нас"
+
+msgid "Contact Us"
+msgstr "Контакт"
+
+msgid "Development"
+msgstr "Развој"
+
+msgid "Our experience with orders and clients grows every day."
+msgstr "Нашето искуство со нарачки и клиенти расте секој ден."
+
+msgid "How do I place an order?"
+msgstr "Како да направам нарачка?"
+
+msgid "Select a product and follow the checkout instructions."
+msgstr "Изберете производ и следете ги упатствата за нарачка."
+
+msgid "What payment methods are available?"
+msgstr "Кои начини на плаќање се достапни?"
+
+msgid "We currently offer cash on delivery."
+msgstr "Моментално нудиме плаќање при достава."
+
+msgid "Certificates & Compliance"
+msgstr "Сертификати и усогласеност"


### PR DESCRIPTION
## Summary
- Redesign navbar with logo, page links, search, and flag-based language selection
- Add hero link and development section, simplify footer links, and adjust product carousel
- Provide dedicated About, FAQ, and Contact pages with Macedonian translations

## Testing
- `django-admin compilemessages -l mk -l en -l sq`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f88f8c688330958fb7390177d3f7